### PR TITLE
fix: add autoplay for sound and suggest translations in audio-challenge

### DIFF
--- a/src/features/games/audio-challenge/AudioChallengeTurn.tsx
+++ b/src/features/games/audio-challenge/AudioChallengeTurn.tsx
@@ -41,7 +41,7 @@ const AudioChallengeTurn = ({
   }, [turn]);
 
   const isGuessCorrect = (): boolean => {
-    return selectedWord === correctWord.word;
+    return selectedWord === correctWord.wordTranslate;
   };
 
   const handleSelect = (word: string): void => {
@@ -79,6 +79,7 @@ const AudioChallengeTurn = ({
             soundSrc={correctWordSoundSrc}
             diameter={selectedWord ? '2rem' : '7rem'}
             variant="warning"
+            autoplay
           />
           <span
             className={`fs-5 ${selectedWord ? '' : 'd-none'}`}
@@ -86,10 +87,10 @@ const AudioChallengeTurn = ({
         </div>
       </div>
       <div className="incorrect-words d-flex gap-3">
-        {allWords.map(({ id, word }) => (
+        {allWords.map(({ id, wordTranslate }) => (
           <GuessWordButton
             key={id}
-            word={word}
+            word={wordTranslate}
             isCorrect={id === correctWord.id}
             turn={turn}
             disabled={!!selectedWord}

--- a/src/features/shared/sound-button/SoundButton.tsx
+++ b/src/features/shared/sound-button/SoundButton.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useRef, useState } from 'react';
+import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from 'react-bootstrap';
 import playAudioAsync from '../../../utils/sound';
 import styles from './SoundButton.module.scss';
@@ -9,17 +9,19 @@ interface SoundButtonProps {
   soundSrc: string | string[];
   diameter?: string;
   variant?: 'primary' | 'secondary' | 'warning' | 'danger' | 'info';
+  autoplay?: boolean;
 }
 
 const SoundButton = ({
   soundSrc,
   diameter = '2rem',
   variant = 'primary',
+  autoplay = false,
 }: SoundButtonProps): JSX.Element => {
   const [playing, setPlaying] = useState(false);
   const soundRef = useRef<HTMLAudioElement>();
 
-  const play = async () => {
+  const play = useCallback(async () => {
     if (!playing) {
       setPlaying(true);
 
@@ -44,7 +46,14 @@ const SoundButton = ({
         soundRef.current.pause();
       }
     }
-  };
+  }, [soundSrc, playing]);
+
+  useEffect(() => {
+    if (autoplay) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      play();
+    }
+  }, [soundSrc, autoplay]);
 
   return (
     <Button


### PR DESCRIPTION
Исправлено по комментариям из кросс-чека:
1. Варианты слов теперь подкидываются на русском, а не на английском
2. Реализовано автоматическое проигрывание звука в игре (в карточках словаря - проверено, все по-прежнему).  
P.S. Мерджу сам без согласования, чтобы быстрее в деплой вошло.