### PR TITLE
Fix games

### DIFF
--- a/src/features/dictionary/chapter-layout/ChapterLayout.tsx
+++ b/src/features/dictionary/chapter-layout/ChapterLayout.tsx
@@ -51,7 +51,7 @@ const ChapterLayout = () => {
           pageCount={chapter === '7' ? 1 : 30}
           isCurrentPageLearned={isCurrentPageLearned}
         />
-        <GamesLinks />
+        <GamesLinks disabled={isCurrentPageLearned} />
       </Stack>
       <div className={styles.wordCardsWrapper}>
         <Outlet />

--- a/src/features/dictionary/games-links/GamesLinks.tsx
+++ b/src/features/dictionary/games-links/GamesLinks.tsx
@@ -6,7 +6,11 @@ import { buildQueryString } from '../../../utils/url';
 
 const REGULAR_CHAPTERS_COUNT = 6;
 
-const GamesLinks = (): JSX.Element => {
+interface GamesLinksProps {
+  disabled: boolean;
+}
+
+const GamesLinks = ({ disabled }: GamesLinksProps): JSX.Element => {
   const [collapseOpen, setCollapseOpen] = useState(false);
   const { chapter, page } = useParams();
 
@@ -33,10 +37,14 @@ const GamesLinks = (): JSX.Element => {
         <div id="mini-games-links">
           <Stack direction="horizontal" gap={2} className="justify-content-center mt-2">
             <LinkContainer to={`/games/audio-challenge${buildQueryString(searchParams)}`}>
-              <Button variant="warning">Play Audio Challenge</Button>
+              <Button variant="warning" disabled={disabled}>
+                Play Audio Challenge
+              </Button>
             </LinkContainer>
             <LinkContainer to={`/games/sprint${buildQueryString(searchParams)}`}>
-              <Button variant="warning">Play Sprint</Button>
+              <Button variant="warning" disabled={disabled}>
+                Play Sprint
+              </Button>
             </LinkContainer>
           </Stack>
         </div>

--- a/src/features/dictionary/word-card/WordCard.tsx
+++ b/src/features/dictionary/word-card/WordCard.tsx
@@ -173,17 +173,17 @@ const RenderFooter = ({
     }
   }
 
-  async function difficultCheckboxHandler() {
-    await changeWordState('isDifficult', !difficult);
-    if (difficultChapterUpdateHandler) await difficultChapterUpdateHandler();
-    setDifficult(!difficult);
-  }
-
   async function learnedCheckboxHandler() {
     await changeWordState('isLearned', !learned);
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     dispatch(fetchUserPages(userId));
     setLearned(!learned);
+  }
+  async function difficultCheckboxHandler() {
+    await changeWordState('isDifficult', !difficult);
+    if (difficultChapterUpdateHandler) await difficultChapterUpdateHandler();
+    setDifficult(!difficult);
+    if (!difficult && learned) await learnedCheckboxHandler();
   }
 
   return (

--- a/src/features/games/audio-challenge/AudioChallengeRound.tsx
+++ b/src/features/games/audio-challenge/AudioChallengeRound.tsx
@@ -113,14 +113,16 @@ const AudioChallengeRound = (): JSX.Element => {
   }, [configured, authorizeStatus, userId, chapter, page, excludeLearnedWords]);
 
   // 3. Prepare for the next turn
-  useEffect(() => {
+  useEffect((): void => {
     if (!enoughWords) {
       return;
     }
 
     // Remove just played word from correct words
     const newCorrectWords =
-      turn === 1 ? [...availableWords] : correctWords.filter(({ id }) => id !== correctWord?.id);
+      turn === 1
+        ? [...availableWords]
+        : correctWords.filter(({ id }: Word): boolean => id !== correctWord?.id);
 
     if (newCorrectWords.length === 0) {
       setEnoughWords(false);
@@ -133,7 +135,9 @@ const AudioChallengeRound = (): JSX.Element => {
     const newCorrectWord = newCorrectWords[randomIndex];
 
     // Generate new set of incorrect words
-    const availableIncorrectWords = availableWords.filter(({ id }) => id !== newCorrectWord.id);
+    const availableIncorrectWords = availableWords.filter(
+      ({ id }: Word): boolean => id !== newCorrectWord.id
+    );
     const newIncorrectWords: Word[] = [];
     for (let i = 1; i < WORDS_PER_TURN && i <= availableIncorrectWords.length; i += 1) {
       randomIndex = Math.floor(Math.random() * (availableIncorrectWords.length - 1));
@@ -196,7 +200,7 @@ const AudioChallengeRound = (): JSX.Element => {
   };
 
   // 5. Show game results
-  useEffect(() => {
+  useEffect((): void => {
     if (finished && userId && authorizeStatus === true) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       saveGameResults(userId, new Date(), 'audio-challenge', gameResult);

--- a/src/features/games/shared/game-result/GameResult.tsx
+++ b/src/features/games/shared/game-result/GameResult.tsx
@@ -7,20 +7,24 @@ import GameResultSection from './GameResultSection';
 interface GameResultProps {
   score: number;
   gameResult: GameTurnResult[];
+  canPlayAgain?: boolean;
 }
 
-const GameResult = ({ score, gameResult }: GameResultProps) => {
+const GameResult = ({ score, gameResult, canPlayAgain = true }: GameResultProps) => {
   const navigate = useNavigate();
   const correctGuesses = gameResult.filter((result: GameTurnResult): boolean => result.wasGuessed);
   const wrongGuesses = gameResult.filter((result: GameTurnResult): boolean => !result.wasGuessed);
 
   return (
-    <Stack gap={3} className="col-sm-9 col-md-7 col-lg-5 my-3 mx-auto flex-grow-0">
+    <Stack gap={3} className="my-3 mx-auto flex-grow-0">
       <h2 className="text-center">Your score: {score}</h2>
       <GameResultSection answers={wrongGuesses} areCorrect={false} />
       <hr className={wrongGuesses.length > 0 && correctGuesses.length > 0 ? '' : 'd-none'} />
       <GameResultSection answers={correctGuesses} areCorrect />
-      <Button className={styles.restartButton} onClick={() => navigate(0)}>
+      <Button
+        className={`${styles.restartButton} ${canPlayAgain ? '' : 'd-none'}`}
+        onClick={() => navigate(0)}
+      >
         Train again
       </Button>
     </Stack>

--- a/src/features/games/shared/saveGameResults.ts
+++ b/src/features/games/shared/saveGameResults.ts
@@ -37,7 +37,7 @@ const updateExistingUserWord = async (
       correctGuessCount: wasGuessed ? 1 : 0,
       wrongGuessCount: wasGuessed ? 0 : 1,
       isLearned: wasGuessed,
-      isDifficult,
+      isDifficult: isDifficult && !wasGuessed,
       optional,
     });
 

--- a/src/features/games/sprint/SprintRound.tsx
+++ b/src/features/games/sprint/SprintRound.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable consistent-return */
 import { useEffect, useMemo, useState } from 'react';
-import { Spinner } from 'react-bootstrap';
+import { Spinner, Stack } from 'react-bootstrap';
 import { useSearchParams } from 'react-router-dom';
 import { getUserWords } from '../../../api/userWords';
 import { getWords } from '../../../api/words';
@@ -52,18 +52,52 @@ const SprintRound = (): JSX.Element => {
   const [availableWords, setAvailableWords] = useState<Word[]>([]);
   const [correctWords, setCorrectWords] = useState<Word[]>([]);
   const [correctWord, setCorrectWord] = useState<Word | null>(null);
+  const [translation, setTranslation] = useState('');
+
+  const [configured, setConfigured] = useState(false);
+  const [enoughWords, setEnoughWords] = useState(false);
+  const [started, setStarted] = useState(false);
+  const [finished, setFinished] = useState(false);
 
   const [level, setLevel] = useState(1);
   const [turn, setTurn] = useState(1);
   const [winsSinceLevelStart, setWinsSinceLevelStart] = useState(0);
   const [gameResult, setGameResult] = useState<GameTurnResult[]>([]);
   const [score, setScore] = useState(0);
-  const [ready, setReady] = useState(false);
-  const [finish, setFinish] = useState(false);
 
-  // Initialize available words
-  useEffect(() => {
-    const loadWords = async () => {
+  // 1. Prompt user to select difficulty level,
+  // unless chapter and page are specified
+  const renderDifficultySelector = (): JSX.Element | undefined => {
+    if (!configured) {
+      if (chapter === undefined && page === undefined) {
+        return <DifficultyLevelSelector show={!configured} onHide={() => setConfigured(true)} />;
+      }
+
+      setConfigured(true);
+    }
+  };
+
+  // Until available words are loaded, render loading spinner
+  const renderLoadingSpinner = (): JSX.Element | undefined => {
+    if (configured && !started) {
+      return (
+        <div className="d-flex flex-column align-items-center gap-2">
+          <Spinner animation="border" variant="primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </Spinner>
+          <h5>Loading words...</h5>
+        </div>
+      );
+    }
+  };
+
+  // 2. Set available words
+  useEffect((): void => {
+    if (!configured) {
+      return;
+    }
+
+    const loadWords = async (): Promise<void> => {
       const allWords = await getWords(chapter, page);
       let freeWords: Word[];
 
@@ -76,50 +110,64 @@ const SprintRound = (): JSX.Element => {
             )
         );
       } else {
-        freeWords = allWords;
+        freeWords = [...allWords];
       }
 
       if (freeWords.length === 0) {
-        setFinish(true);
+        setEnoughWords(false);
+        setFinished(true);
       }
 
       setAvailableWords([...freeWords]);
-      setCorrectWords([...freeWords]);
+      setEnoughWords(true);
+      setStarted(true);
+      setTurn(1);
     };
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadWords();
-  }, [authorizeStatus, chapter, excludeLearnedWords, page, userId]);
+  }, [configured, authorizeStatus, userId, chapter, page, excludeLearnedWords]);
 
-  // Set new correct word
-  useEffect(() => {
-    if (correctWords.length === 0) {
-      if (turn > 1) {
-        setFinish(true);
-      }
-
+  // 3. Prepare for the next turn
+  useEffect((): void => {
+    if (!enoughWords) {
       return;
     }
 
-    const randomIndex = Math.floor(Math.random() * correctWords.length);
-    setCorrectWord(correctWords[randomIndex]);
-  }, [correctWords, turn]);
+    // Remove just played word from correct words
+    const newCorrectWords =
+      turn === 1
+        ? [...availableWords]
+        : correctWords.filter(({ id }: Word): boolean => id !== correctWord?.id);
 
-  const updateCorrectWords = () => {
-    setCorrectWords(correctWords.filter(({ id }) => id !== correctWord?.id));
-  };
+    if (newCorrectWords.length === 0) {
+      setEnoughWords(false);
+      setFinished(true);
+      return;
+    }
 
-  const translation = useMemo((): string => {
-    const source = availableWords.filter((word) => word.id !== correctWord?.id);
-    const randomIndex = Math.floor(Math.random() * (source.length - 1));
-    const randomWord = source[randomIndex];
+    // Set new correct word
+    let randomIndex = Math.floor(Math.random() * newCorrectWords.length);
+    const newCorrectWord = newCorrectWords[randomIndex];
+
+    // Generate translation proposal
+    const availableIncorrectWords = availableWords.filter(
+      ({ id }: Word): boolean => id !== newCorrectWord.id
+    );
+    randomIndex = Math.floor(Math.random() * (availableIncorrectWords.length - 1));
+    const incorrectWord = availableIncorrectWords[randomIndex];
 
     const isTranslationCorrect = Boolean(Math.round(Math.random()));
 
-    return isTranslationCorrect
-      ? correctWord?.wordTranslate || ''
-      : randomWord?.wordTranslate || '';
-  }, [availableWords, correctWord?.id, correctWord?.wordTranslate]);
+    const newTranslation = isTranslationCorrect
+      ? newCorrectWord.wordTranslate || ''
+      : incorrectWord.wordTranslate || '';
+
+    // Update state
+    setCorrectWord(newCorrectWord);
+    setCorrectWords(newCorrectWords);
+    setTranslation(newTranslation);
+  }, [availableWords, enoughWords, turn]);
 
   const levelUp = (): void => {
     const maxLevel = Math.max(...Object.keys(LevelsConfig).map((key) => +key));
@@ -159,43 +207,18 @@ const SprintRound = (): JSX.Element => {
   const handleNextTurn = (isCorrect: boolean): void => {
     updateGameResult(isCorrect);
 
-    if (!finish) {
+    if (!finished) {
       setTurn(turn + 1);
-      updateCorrectWords();
     }
   };
 
   const handleQuit = (): void => {
-    setFinish(true);
+    setFinished(true);
   };
 
-  const renderDifficultySelector = (): JSX.Element | undefined => {
-    if (!ready) {
-      if (chapter === undefined && page === undefined) {
-        return <DifficultyLevelSelector show={!ready} onHide={() => setReady(true)} />;
-      }
-
-      setReady(true);
-    }
-  };
-
-  useEffect(() => {
-    if (finish && userId && authorizeStatus === true) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      saveGameResults(userId, new Date(), 'sprint', gameResult);
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      dispatch(fetchUserPages(userId));
-    }
-  }, [authorizeStatus, chapter, dispatch, finish, gameResult, page, userId]);
-
-  const renderGameResult = (): JSX.Element | undefined => {
-    if (finish) {
-      return <GameResult score={score} gameResult={gameResult} />;
-    }
-  };
-
-  const renderGameRound = (): JSX.Element | undefined => {
-    if (ready && correctWord && !finish) {
+  // 4. Render turn
+  const renderGameTurn = (): JSX.Element | undefined => {
+    if (started && correctWord && !finished) {
       return (
         <SprintTurn
           correctWord={correctWord}
@@ -211,26 +234,38 @@ const SprintRound = (): JSX.Element => {
     }
   };
 
-  const renderLoadingSpinner = (): JSX.Element | undefined => {
-    if (!finish && !correctWord) {
+  // 5. Show game results
+  useEffect((): void => {
+    if (finished && userId && authorizeStatus === true) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      saveGameResults(userId, new Date(), 'sprint', gameResult);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      dispatch(fetchUserPages(userId));
+    }
+  }, [authorizeStatus, chapter, dispatch, finished, gameResult, page, userId]);
+
+  const renderGameResult = (): JSX.Element | undefined => {
+    if (finished) {
       return (
-        <div className="d-flex flex-column align-items-center gap-2">
-          <Spinner animation="border" variant="primary" role="status">
-            <span className="visually-hidden">Loading...</span>
-          </Spinner>
-          <h5>Loading words...</h5>
-        </div>
+        <Stack className="col-sm-9 col-md-7 col-lg-5 my-3 mx-auto flex-grow-0">
+          <GameResult score={score} gameResult={gameResult} canPlayAgain={enoughWords} />
+          <h5 className={`${enoughWords ? 'd-none' : ''} p-2 text-success text-center`}>
+            Looks like you&apos;ve learned all words on this page.
+            <br />
+            Don&apos;t stop and practise further!
+          </h5>
+        </Stack>
       );
     }
   };
 
   const renderCountDown = (): JSX.Element | undefined => {
-    if (ready && correctWord && !finish) {
+    if (started && correctWord && !finished) {
       return (
         <CountDown
           totalTime={ROUND_DURATION}
           tickFrequency={TICK_FREQUENCY}
-          onFinished={() => setFinish(true)}
+          onFinished={() => setFinished(true)}
           className="position-absolute top-0 start-0 m-3"
         />
       );
@@ -242,7 +277,7 @@ const SprintRound = (): JSX.Element => {
       {renderDifficultySelector()}
       {renderLoadingSpinner()}
       {renderCountDown()}
-      {renderGameRound()}
+      {renderGameTurn()}
       {renderGameResult()}
     </div>
   );

--- a/src/features/games/sprint/SprintRound.tsx
+++ b/src/features/games/sprint/SprintRound.tsx
@@ -225,7 +225,7 @@ const SprintRound = (): JSX.Element => {
   };
 
   const renderCountDown = (): JSX.Element | undefined => {
-    if (ready && !finish) {
+    if (ready && correctWord && !finish) {
       return (
         <CountDown
           totalTime={ROUND_DURATION}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,27 +21,27 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
 root.render(
   <Provider store={store}>
-    <React.StrictMode>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<App />}>
-            <Route index element={<MainPage />} />
-            <Route path="dictionary" element={<Dictionary />}>
-              <Route index element={<ChaptersHint />} />
-              <Route path="chapters/:chapter" element={<ChapterLayout />}>
-                <Route path="pages/:page" element={<ChapterPageLayout />} />
-              </Route>
+    {/* <React.StrictMode> */}
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />}>
+          <Route index element={<MainPage />} />
+          <Route path="dictionary" element={<Dictionary />}>
+            <Route index element={<ChaptersHint />} />
+            <Route path="chapters/:chapter" element={<ChapterLayout />}>
+              <Route path="pages/:page" element={<ChapterPageLayout />} />
             </Route>
-            <Route path="games" element={<Games />}>
-              <Route index element={<GamesList />} />
-              <Route path="audio-challenge" element={<AudioChallengeRound />} />
-              <Route path="sprint" element={<SprintRound />} />
-            </Route>
-            <Route path="statistics" element={<Statistics />} />
-            <Route path="auth" element={<Auth />} />
           </Route>
-        </Routes>
-      </BrowserRouter>
-    </React.StrictMode>
+          <Route path="games" element={<Games />}>
+            <Route index element={<GamesList />} />
+            <Route path="audio-challenge" element={<AudioChallengeRound />} />
+            <Route path="sprint" element={<SprintRound />} />
+          </Route>
+          <Route path="statistics" element={<Statistics />} />
+          <Route path="auth" element={<Auth />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+    {/* </React.StrictMode> */}
   </Provider>
 );


### PR DESCRIPTION
1. Вроде бы убрал двойной рендер первого хода в играх
2. Если слова заканчиваются, то видоизменяется форма экрана с результатами игры
3. Вернул деактивацию ссылок на мини-игры на полностью изученных страницах
4. Пофиксил взаимодействие между флагами Сложное/Изученное в карточке слова и при сохранении результатов игры (см. коммиты)

**Пожалуйста, погоняйте хорошенько, не вылазят ли новые баги после изменений.**

Known issues:
1. После игры при авторизованном пользователе нажатие Train again вызывает двойной рендер первого хода - это из-за того, что эта кнопка перезагружает страницу, и на долю секунды статус авторизации слетает на неавторизованный